### PR TITLE
Updated description in app.json

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -10,8 +10,8 @@
     "en": "Luxtronik"
   },
   "description": {
-    "en": "Adds support for Luxtronik Devices.",
-    "nl": "Voegt Luxtronik apparaten toe aan homey!"
+    "en": "Use your heatpump to its full potential!",
+    "nl": "Gebruik alle mogelijkheden van je warmtepomp!"
   },
   "category": [
     "climate"

--- a/app.json
+++ b/app.json
@@ -11,8 +11,8 @@
     "en": "Luxtronik"
   },
   "description": {
-    "en": "Adds support for Luxtronik Devices.",
-    "nl": "Voegt Luxtronik apparaten toe aan homey!"
+    "en": "Use your heatpump to its full potential!",
+    "nl": "Gebruik alle mogelijkheden van je warmtepomp!"
   },
   "category": [
     "climate"


### PR DESCRIPTION
This fixes #7 as this adds a description that is compliant with the Homey Guidelines outlined here https://apps.developer.homey.app/app-store/guidelines#1.2.-description

> The description field is a required field to provide your app with a catchy tagline to grab the user's attention. The description is shown beneath your app's name and above the readme in the App Store. In case your app supports devices by a specific brand, consider using their slogan as your description.
> Using your app's name or repeating text from the readme in your description is not allowed.
> The description field is not meant for an extensive text. Provide an engaging one-liner that highlights the purpose of your app. In case your app supports devices by a specific brand, consider using their slogan as your description.
> All apps in the Homey App Store add support for something to Homey, that is why they are there. So avoid descriptions such as these:
> "Adds support for Sonos"
> "Integrates Philips Hue with Homey"
> "Control your Ikea devices with the Ikea app"
> What we'd like to see:
> Philips Hue - "Transform the way you experience light"
> Ikea - "Create the right atmosphere for every mood"
> Rituals - "Your home never smelled smarter"
> Heimdall - "Turn Homey into a surveillance system"